### PR TITLE
Updates to allow for building on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Use `macdeployqt` to copy in the necessary Frameworks and other files.
 ```
 
 ### Linux
-1. Make sure you have Qt5 and cmake installed.  If not, use your package manager to install them, e.g. `yum install cmake` or `pacman -S cmake`
+1. Make sure you have Qt5 >= 5.10.0 and cmake installed.  If not, use your package manager to install them, e.g. `yum install cmake` or `pacman -S cmake`. You can also install Qt5 from the [offical website](http://download.qt.io/official_releases/qt/) if the correct version is not available in your package manager.
 2. Clone the Huestacean project and make sure all submodules are up to date.
 ```
 git clone --recursive git://github.com/BradyBrenot/huestacean.git
@@ -152,7 +152,7 @@ cd huestacean
 git submodule sync
 git submodule update --init --recursive
 ```
-3. Use cmake to build Huestacean.
+3. Use cmake to build Huestacean, or build it with QtCreator.
 ```
 mkdir build
 cd build

--- a/include/entertainment.h
+++ b/include/entertainment.h
@@ -12,6 +12,9 @@ class EntertainmentLight : public Light
     Q_PROPERTY(double y MEMBER y NOTIFY propertiesChanged)
     Q_PROPERTY(double z MEMBER z NOTIFY propertiesChanged)
 
+signals:
+    void propertiesChanged();
+
 public:
     double x;
     double y;
@@ -69,6 +72,9 @@ class EntertainmentGroup : public BridgeObject
     Q_PROPERTY(bool isStreaming MEMBER isStreaming NOTIFY isStreamingChanged)
     Q_PROPERTY(QList<EntertainmentLight> lights MEMBER lights NOTIFY propertiesChanged)
     Q_PROPERTY(QString asString READ toString NOTIFY propertiesChanged)
+
+signals:
+    void propertiesChanged();
 
 public:
     explicit EntertainmentGroup(HueBridge *parent);

--- a/include/huebridge.h
+++ b/include/huebridge.h
@@ -137,6 +137,9 @@ class Light : public BridgeObject
 
     Q_PROPERTY(QString name MEMBER name NOTIFY propertiesChanged)
 
+signals:
+    void propertiesChanged();
+
 public:
     explicit Light() : BridgeObject(nullptr)
     {


### PR DESCRIPTION
I made some minor modifications to `include/entertainment.h` and `include/huebridge.h` that allow for compilation on Linux. I have successfully tested this on Ubuntu 18.04 with Qt 5.11.0. In addition, I added some very minor changes to the readme with additional instructions for building on Linux.

I **HAVE NOT** tested these changes on other platforms, so I highly suggest that is tested prior to merging.