### PR TITLE
Add cmake -Wno-dev to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ git submodule update --init --recursive
 ```
 mkdir build
 cd build
-cmake ..
+cmake -Wno-dev ..
 make huestacean
 ```
 Run Huestacean and enjoy!  (`.../huestacean/build/huestacean`)


### PR DESCRIPTION
This hides a lot of warnings which make it harder to see real errors, such as missing dependencies from #151.